### PR TITLE
added get configured services function

### DIFF
--- a/stakkr/stakkr_compose.py
+++ b/stakkr/stakkr_compose.py
@@ -90,6 +90,10 @@ def get_enabled_services(configured_services: list):
 
     return services_files
 
+def get_configured_services(config_file: str = None):
+    # Services configured in the given config file. 
+    configured_services = get_main_config(config_file).get('services')
+    return configured_services
 
 def get_main_config(config: str):
     config = Config(config)


### PR DESCRIPTION
To call get_enabled_services it would be useful to be able to make get the configured services with a function to pass as argument.