### PR TITLE
Add traefik version choice

### DIFF
--- a/stakkr/actions.py
+++ b/stakkr/actions.py
@@ -130,7 +130,7 @@ class StakkrActions:
         self._run_iptables_rules(cts)
         if proxy is True:
             conf = self.config['proxy']
-            Proxy(conf.get('http_port'), conf.get('https_port')).start(
+            Proxy(conf.get('http_port'), conf.get('https_port'), version=conf.get('version')).start(
                 docker.get_network_name(self.project_name))
 
     def status(self):

--- a/stakkr/proxy.py
+++ b/stakkr/proxy.py
@@ -10,11 +10,12 @@ from stakkr.file_utils import get_dir
 class Proxy:
     """Main class that does actions asked by the cli."""
 
-    def __init__(self, http_port: int = 80, https_port: int = 443, ct_name: str = 'proxy_stakkr'):
+    def __init__(self, http_port: int = 80, https_port: int = 443, ct_name: str = 'proxy_stakkr', version: str = 'latest'):
         """Set the right values to start the proxy."""
         self.ports = {'http': http_port, 'https': https_port}
         self.ct_name = ct_name
         self.docker_client = docker.get_client()
+        self.version = version
 
     def start(self, stakkr_network: str = None):
         """Start stakkr proxy if stopped."""
@@ -39,9 +40,9 @@ class Proxy:
         """Start proxy."""
         proxy_conf_dir = get_dir('static/proxy')
         try:
-            self.docker_client.images.pull('traefik:latest')
+            self.docker_client.images.pull('traefik:{}'.format(self.version))
             self.docker_client.containers.run(
-                'traefik:latest', remove=True, detach=True,
+                'traefik:{}'.format(self.version), remove=True, detach=True,
                 hostname=self.ct_name, name=self.ct_name,
                 volumes=[
                     '/var/run/docker.sock:/var/run/docker.sock',

--- a/stakkr/static/config_default.yml
+++ b/stakkr/static/config_default.yml
@@ -17,6 +17,7 @@ proxy:
   domain: localhost
   http_port: 80
   https_port: 443
+  version: latest
 
 project_name: ''
 

--- a/stakkr/static/config_default.yml
+++ b/stakkr/static/config_default.yml
@@ -17,7 +17,7 @@ proxy:
   domain: localhost
   http_port: 80
   https_port: 443
-  version: latest
+  version: 1.7.0
 
 project_name: ''
 

--- a/stakkr/static/config_schema.yml
+++ b/stakkr/static/config_schema.yml
@@ -60,7 +60,8 @@ properties:
       domain: { type: string }
       http_port: { type: integer }
       https_port: { type: integer }
-    required: [enabled, domain, http_port, https_port]
+      version: { type: [string, number] }
+    required: [enabled, domain, http_port, https_port, version]
 
   project_name:
     type: string


### PR DESCRIPTION
With the version 2.0 of Traefik, Stakkr was unable to run some containers, a simple trick is to downgrade Traefik, so now, we can choose the version in stakkr.yml